### PR TITLE
Updated renderer for bottom tabs in Android

### DIFF
--- a/TabReselectDemo/TabReselectDemo.Android/MainTabPageRenderer.cs
+++ b/TabReselectDemo/TabReselectDemo.Android/MainTabPageRenderer.cs
@@ -19,13 +19,46 @@ using TabReselectDemo.Droid;
 [assembly: Xamarin.Forms.ExportRenderer(typeof(MainPage), typeof(MainTabPageRenderer))]
 namespace TabReselectDemo.Droid
 {
-    public class MainTabPageRenderer : TabbedPageRenderer, TabLayout.IOnTabSelectedListener
+    public class MainTabPageRenderer : TabbedPageRenderer, TabLayout.IOnTabSelectedListener, BottomNavigationView.IOnNavigationItemReselectedListener
     {
         public MainTabPageRenderer(Context context) : base(context)
         {
         }
 
         void TabLayout.IOnTabSelectedListener.OnTabReselected(TabLayout.Tab tab)
+        {
+            if (Element is MainPage)
+            {
+                var mainTabPage = Element as MainPage;
+                mainTabPage.NotifyTabReselected();
+            }
+        }
+
+        protected override void OnElementChanged(ElementChangedEventArgs<TabbedPage> e)
+        {
+            base.OnElementChanged(e);
+
+            if (e.OldElement == null && e.NewElement != null)
+            {
+                for (int i = 0; i <= this.ViewGroup.ChildCount - 1; i++)
+                {
+                    var childView = this.ViewGroup.GetChildAt(i);
+                    if (childView is ViewGroup viewGroup)
+                    {
+                        for (int j = 0; j <= viewGroup.ChildCount - 1; j++)
+                        {
+                            var childRelativeLayoutView = viewGroup.GetChildAt(j);
+                            if (childRelativeLayoutView is BottomNavigationView bottomNavigationView)
+                            {
+                                bottomNavigationView.SetOnNavigationItemReselectedListener(this);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        void BottomNavigationView.IOnNavigationItemReselectedListener.OnNavigationItemReselected(IMenuItem item)
         {
             if (Element is MainPage)
             {


### PR DESCRIPTION
When Android tabs are on the bottom we need to implement BottomNavigationView.IOnNavigationItemReselectedListener sift through the ViewGroup and set listener on BottomNavigationView. 